### PR TITLE
Change for Frozen String literal ruby 3.4+

### DIFF
--- a/lib/fog/rackspace/requests/storage/get_object.rb
+++ b/lib/fog/rackspace/requests/storage/get_object.rb
@@ -31,7 +31,7 @@ module Fog
           c = mock_container! container
           o = c.mock_object! object
 
-          body, size = "", 0
+          body, size = String.new, 0
 
           o.each_part do |part|
             body << part.body


### PR DESCRIPTION
change of default behavior currently on warning. 
https://bugs.ruby-lang.org/issues/20205

